### PR TITLE
Fix broken autocomplete selection in vscode 1.57.0

### DIFF
--- a/themes/Lilac-color-theme.json
+++ b/themes/Lilac-color-theme.json
@@ -472,6 +472,7 @@
 		"list.activeSelectionForeground": "#080709",
 		"list.inactiveSelectionBackground": "#080709",
 		"list.focusBackground": "#2e2834",
+		"list.highlightForeground": "#a299f7",
 		"editorLineNumber.foreground": "#3b3442",
 		"editorIndentGuide.background": "#211d26",
 		"editorWhitespace.foreground": "#211d26",
@@ -569,6 +570,7 @@
 		"scrollbar.shadow": "#000000",
 		"editorSuggestWidget.highlightForeground": "#a29dfa",
 		"editorSuggestWidget.foreground": "#e0ceed",
+		"editorSuggestWidget.selectedForeground": "#e0cdec",
 		"editorSuggestWidget.selectedBackground": "#3b3442"
 	}
 }


### PR DESCRIPTION
The 1.57 vscode update seems to have broken the selected autocompletion entry colors. This should make it look like it used to before (tested in latest vscodium)